### PR TITLE
Ensure ascii char range includes z; Closes #2

### DIFF
--- a/Scrabblinator/ScrabbleText.fs
+++ b/Scrabblinator/ScrabbleText.fs
@@ -25,7 +25,7 @@ module ScrabbleText =
 
     let asciiChar = 
         seq { 65 .. 90 }
-        |> Seq.append (seq { 97 .. 121 })
+        |> Seq.append (seq { 97 .. 122 })
         |> Seq.map char
         |> Set.ofSeq
 


### PR DESCRIPTION
Closes #2 by adding 'z' to the range of accepted ascii characters ('z' is ascii char 122, per http://www.asciitable.com/ ).